### PR TITLE
adds warn method for raising an error for specified keys

### DIFF
--- a/lib/strong_parameters.rb
+++ b/lib/strong_parameters.rb
@@ -315,6 +315,15 @@ module StrongParameters
       params.permit!
     end
 
+    def warn(*filters)
+      self['data'].each do |data_hash|
+        rejectables = data_hash.symbolize_keys.keys & filters.flatten
+        raise StrongParameters::Error::UnpermittedParameters.new(rejectables) if rejectables.present?
+      end
+      self
+    end
+
+
     # Returns a parameter for the given +key+. If not found,
     # returns +nil+.
     #

--- a/lib/strong_parameters.rb
+++ b/lib/strong_parameters.rb
@@ -318,11 +318,10 @@ module StrongParameters
     def warn(*filters)
       self['data'].each do |data_hash|
         rejectables = data_hash.symbolize_keys.keys & filters.flatten
-        raise StrongParameters::Error::UnpermittedParameters.new(rejectables) if rejectables.present?
+        raise StrongParameters::Error::RejectedParameters.new(rejectables) if rejectables.present?
       end
       self
     end
-
 
     # Returns a parameter for the given +key+. If not found,
     # returns +nil+.

--- a/lib/strong_parameters/error.rb
+++ b/lib/strong_parameters/error.rb
@@ -31,5 +31,15 @@ module StrongParameters
         super("found unpermitted parameter#{'s' if params.size > 1 }: #{params.join(', ')}")
       end
     end
+
+    class RejectedParameters < IndexError
+      attr_reader :params
+
+      def intitialize(params)
+        @params = params
+        super("Cannot accept parameter#{'s' if params.size > 1 }: #{params.join(', ')}")
+      end
+    end
+
   end
 end

--- a/lib/strong_parameters/error.rb
+++ b/lib/strong_parameters/error.rb
@@ -35,7 +35,7 @@ module StrongParameters
     class RejectedParameters < IndexError
       attr_reader :params
 
-      def intitialize(params)
+      def initialize(params)
         @params = params
         super("Cannot accept parameter#{'s' if params.size > 1 }: #{params.join(', ')}")
       end

--- a/test/raise_on_unpermitted_params_test.rb
+++ b/test/raise_on_unpermitted_params_test.rb
@@ -27,3 +27,22 @@ class RaiseOnUnpermittedParamsTest < ActiveSupport::TestCase
     end
   end
 end
+
+
+
+class RaiseOnRejectedParamsTest < ActiveSupport::TestCase
+  test 'raises on rejected params' do
+    params = ActionController::Parameters.new(
+      data: [{
+        book: {pages: 65},
+        fishing: 'Turnips',
+        cooking: 'spaghetti'
+      }]
+    )
+
+    assert_raises(ActionController::RejectedParameters) do
+      params.warn(:cooking).permit(book: [:pages])
+    end
+  end
+
+end


### PR DESCRIPTION
This allows a `warn` method to be chained to strong params, before the permit method. Example:

`StrongParameters::Parameters.new(params).warn(:id).permit(data: [:name, :headline])`

In the above example, a hash with :id will return an error, but a hash with :description would just filter out the :description key/value. 
